### PR TITLE
ImageShape plugin, form focus, extra fields fix, rel attribute fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # summernote-image-attributes
 A plugin for the [Summernote](https://github.com/summernote/summernote/) WYSIWYG editor.
 
-Adds a button to the image popover to edit title, alt, class and style attributes.
+Adds a button to the image popover to edit title, alt, class and style attributes (imageAttributes plugin alias)
+
+It can also optionally add a dropdown to choose from Bootstrap image shapes (imageShape plugin alias)
 
 ![summernote-image-attributes-popover](https://github.com/StudioJunkyard/summernote-image-attributes/blob/master/summernote-image-attributes-popover.png)
 
@@ -30,9 +32,9 @@ $(document).ready(function() {
     $('#summernote').summernote({
         popover: {
             image: [
-                ['custom', ['imageAttributes']],
                 ['imagesize', ['imageSize100', 'imageSize50', 'imageSize25']],
                 ['float', ['floatLeft', 'floatRight', 'floatNone']],
+                ['custom', ['imageAttributes', 'imageShape']],
                 ['remove', ['removeMedia']]
             ],
         },
@@ -40,6 +42,9 @@ $(document).ready(function() {
         imageAttributes:{
             icon:'<i class="note-icon-pencil"/>', // This Icon is from the LibreICONS class Extras and SVG Icons for Summernote.
             removeEmpty:false // true = remove attributes | false = leave empty if present
+        }
+        imageShape: {
+            icon: '<i class="note-icon-picture"/>'
         }
     });
 });

--- a/summernote-image-attributes.js
+++ b/summernote-image-attributes.js
@@ -18,6 +18,7 @@
                 title:'Title',
                 alt:'Alt',
                 class:'Class',
+                classSelect:'Select Class',
                 style:'Style',
                 href:'URL',
                 target:'Target',
@@ -48,6 +49,7 @@
                 title:'Titulo',
                 alt:'Alternativo',
                 class:'Clases',
+                classSelect:'Selecciona Forma',
                 style:'Estilo',
                 href:'URL',
                 target:'Destino',
@@ -75,7 +77,9 @@
             removeEmpty:true
         },
         imageShape: {
-            icon: '<i class="note-icon-picture"/>'
+            icon: '<i class="note-icon-picture"/>',
+            /* Must keep the same order as in lang.imageAttributes.tooltipShapeOptions */
+            shapes: [ 'img-rounded', 'img-circle', 'img-thumbnail', '' ]
         }
     })
     $.extend($.summernote.plugins,{
@@ -99,6 +103,10 @@
             });
             this.initialize=function(){
                 var $container=options.dialogsInBody?$(document.body):$editor;
+                var $shapesOptions = '';
+                $.each( options.imageShape.shapes, function( index, value ) {
+                	if(value) $shapesOptions = $shapesOptions + '<option value="' + value + '">' + lang.imageAttributes.tooltipShapeOptions[index] + '</option>'
+                });
                 var body='<h5>'+lang.imageAttributes.pluginImageTitle+'</h5>'+
                         '<div class="form-group">'+
                             '<label class="control-label col-xs-2">'+lang.imageAttributes.title+'</label>'+
@@ -118,11 +126,8 @@
                         '<input type="text" class="note-image-attributes-class form-control">'+
                         '<div class="input-group-btn">'+
                             '<select class="note-image-attributes-class-select btn btn-default">'+
-                                '<option value="">Select Class</option>'+
-                                '<option value="img-responsive">Responsive</option>'+
-                                '<option value="img-rounded">Rounded</option>'+
-                                '<option value="img-circle">Circle</option>'+
-                                '<option value="img-thumbnail">Thumbnail</option>'+
+                                '<option value="">' + lang.imageAttributes.classSelect + '</option>'+
+                                $shapesOptions+
                             '</select>'+
                         '</div>'+
                     '</div>'+
@@ -195,12 +200,17 @@
                 });
             };
             this.bindLabels=function(){
+            	self.$dialog.find('.form-control:first').focus().select();
             	self.$dialog.find('label').on('click', function() {
             		$(this).parent().find('.form-control:first').focus();
             	});
             };
             this.bindClassesSelector=function(){
             	$('.note-image-attributes-class-select').on('change', function() {
+					/* Options are mutually exclusive, so we just remove the others before adding */
+					$.each( options.imageShape.shapes, function( index, value ) {
+						$('.note-image-attributes-class').val( $('.note-image-attributes-class').val().replace(value, "") );
+					});
 					$('.note-image-attributes-class').val(
 						$.unique( /* Ensure no duplicate classes */
 							$.trim( $('.note-image-attributes-class').val() + ' ' + $(this).val() ) /* Concat and trim */
@@ -339,8 +349,6 @@
             var $note=context.layoutInfo.note;
             var options=context.options;
             var lang=options.langInfo;
-            /* Must keep the same order as in lang.imageAttributes.tooltipShapeOptions */
-            var shapes = [ 'img-rounded', 'img-circle', 'img-thumbnail', '' ];
             context.memo('button.imageShape',function(){
             	var button = ui.buttonGroup([
             		ui.button({
@@ -359,9 +367,8 @@
             					var $img=$($editable.data('target'));
             					var index = $.inArray( $button.data('value'), lang.imageAttributes.tooltipShapeOptions );
             					/* Options are mutually exclusive, so we just remove the others before adding */
-            					$.each( shapes, function( index, value ) { $img.removeClass(value); });
-            					$img.addClass( shapes[index] );
-
+            					$.each( options.imageShape.shapes, function( index, value ) { $img.removeClass(value); });
+            					$img.addClass( options.imageShape.shapes[index] );
             					context.invoke('editor.afterCommand');
             				}
             		})

--- a/summernote-image-attributes.js
+++ b/summernote-image-attributes.js
@@ -11,6 +11,8 @@
         'en-US':{
             imageAttributes:{
                 tooltip:'Image Attributes',
+                tooltipShape:'Image Shape',
+                tooltipShapeOptions: [ 'Rounded', 'Circle', 'Thumbnail', 'None' ],
                 pluginImageTitle:'Image Attributes',
                 pluginLinkTitle:'Link Attributes',
                 title:'Title',
@@ -39,6 +41,8 @@
         'es-ES':{
             imageAttributes:{
                 tooltip:'Propiedades de la Imagen',
+                tooltipShape:'Forma de la Imagen',
+                tooltipShapeOptions: [ 'Borde Redondeado', 'Formato Circular', 'Marco de foto', 'Normal' ],
                 pluginImageTitle:'Atributos de la Imagen',
                 pluginLinkTitle:'Atributos del Enlace',
                 title:'Titulo',
@@ -66,9 +70,12 @@
         }
     });
     $.extend($.summernote.options,{
-        imageAttributes:{
-            icon:'<i class="note-icon-pencil"/>',
+        imageAttributes: {
+            icon: '<i class="note-icon-pencil"/>',
             removeEmpty:true
+        },
+        imageShape: {
+            icon: '<i class="note-icon-picture"/>'
         }
     })
     $.extend($.summernote.plugins,{
@@ -130,13 +137,13 @@
                 '<div class="form-group">'+
                     '<label class="control-label col-xs-2">'+lang.imageAttributes.href+'</label>'+
                     '<div class="input-group col-xs-10">'+
-                        '<input type="text" class="note-image-attributes-href form-control" name="href">'+
+                        '<input type="text" class="note-image-attributes-href form-control">'+
                     '</div>'+
                 '</div>'+
                 '<div class="form-group">'+
                     '<label class="control-label col-xs-2">'+lang.imageAttributes.target+'</label>'+
                     '<div class="input-group col-xs-10">'+
-                        '<select class="note-image-attributes-target form-control" name="target">'+
+                        '<select class="note-image-attributes-target form-control">'+
                             '<option value="_self">Self</option>'+
                             '<option value="_blank">Blank</option>'+
                             '<option value="_top">Top</option>'+
@@ -147,13 +154,13 @@
                 '<div class="form-group">'+
                     '<label class="control-label col-xs-2">'+lang.imageAttributes.linkClass+'</label>'+
                     '<div class="input-group col-xs-10">'+
-                        '<input type="text" class="note-image-attributes-link-class form-control" name="linkClass">'+
+                        '<input type="text" class="note-image-attributes-link-class form-control">'+
                     '</div>'+
                 '</div>'+
                 '<div class="form-group">'+
                     '<label class="control-label col-xs-2">'+lang.imageAttributes.rel+'</label>'+
                     '<div class="input-group col-xs-10">'+
-                        '<select class="note-image-attributes-link-rel form-control" name="linkRel">'+
+                        '<select class="note-image-attributes-link-rel form-control">'+
                             '<option value="">'+lang.imageAttributes.relBlank+'</option>'+
                             '<option value="alternate">'+lang.imageAttributes.relAlternate+'</option>'+
                             '<option value="author">'+lang.imageAttributes.relAuthor+'</option>'+
@@ -256,7 +263,7 @@
                             lnktxt+=' href="'+imgInfo.href+'"';
                             lnktxt+=' target="'+imgInfo.target+'"';
                             if(imgInfo.linkRel){
-                                lnktxt+=' ref="'+imgInfo.linkRel+'"';
+                                lnktxt+=' rel="'+imgInfo.linkRel+'"';
                             }
                             lnktxt+='></a>';
                             $img.wrap(lnktxt);
@@ -325,6 +332,42 @@
                     ui.showDialog(self.$dialog);
                 });
             };
+        },
+        'imageShape':function(context){
+            var ui=$.summernote.ui;
+            var $editable=context.layoutInfo.editable;
+            var $note=context.layoutInfo.note;
+            var options=context.options;
+            var lang=options.langInfo;
+            /* Must keep the same order as in lang.imageAttributes.tooltipShapeOptions */
+            var shapes = [ 'img-rounded', 'img-circle', 'img-thumbnail', '' ];
+            context.memo('button.imageShape',function(){
+            	var button = ui.buttonGroup([
+            		ui.button({
+            			className: 'dropdown-toggle',
+            			contents: options.imageShape.icon + ' <span class="caret"></span>',
+            			tooltip: lang.imageAttributes.tooltipShape,
+            			data: {
+            				toggle: 'dropdown'
+            			}
+            		}),
+            		ui.dropdown({
+            			className: 'dropdown-shape',
+            			items: lang.imageAttributes.tooltipShapeOptions,
+            			click: function (event) {
+            					var $button = $(event.target);
+            					var $img=$($editable.data('target'));
+            					var index = $.inArray( $button.data('value'), lang.imageAttributes.tooltipShapeOptions );
+            					/* Options are mutually exclusive, so we just remove the others before adding */
+            					$.each( shapes, function( index, value ) { $img.removeClass(value); });
+            					$img.addClass( shapes[index] );
+
+            					context.invoke('editor.afterCommand');
+            				}
+            		})
+            	]);
+                return button.render();
+            });
         }
     });
 }));


### PR DESCRIPTION
General changes:
- Optionally adds a dropdown to choose from Bootstrap image shapes (imageShape plugin alias)
- Fixed fields with name attributes creating unwanted extra form fields being posted when dialogsInBody:false
- Fixed typo that was storing a "ref" attribute instead of the correct "rel" ( f / l )
- Now First field is focused (and it's content selected) on popup opening, so you can use the keyboard to tab-fill all form fields

Related to new feature "Image shapes":
- Moved image shapes as an option, so it can be extended easily
- Now both bar dropdown & popup dropdown selector uses the same shapes collection
- Now everything respect language (even dropdown empty option + shapes)
- Shapes are now mutually exclusive in the popup too
