### PR TITLE
propagate change event to onChange callback

### DIFF
--- a/summernote-image-attributes.js
+++ b/summernote-image-attributes.js
@@ -340,6 +340,8 @@
                 linkStyle:  $linkStyle.val(),
                 linkRel:    $linkRel.val(),
                 linkRole:   $linkRole.val()
+              }).then((img) => {
+                context.triggerEvent('change', $editable.html());
               });
             });
             $imageTitle.val(imgInfo.title);


### PR DESCRIPTION
`summernote` allows you to attach to the [`onchange` callback ](https://summernote.org/deep-dive/#onchange). When using [react-summernote](https://github.com/summernote/react-summernote) this is the normal way to capture the change and save it.

The change event is not propagated when image attributes are applied. You have to do at least one interaction with the editor to get the changes reported to the callback.

This is a fix to propagate the change event up when the user applies the image attribute changes and let the user save the changes immediately.